### PR TITLE
imagebox: add a "cover" fit policy

### DIFF
--- a/lib/wibox/widget/imagebox.lua
+++ b/lib/wibox/widget/imagebox.lua
@@ -203,6 +203,8 @@ function imagebox:draw(ctx, cr, width, height)
                 aspects[aspect] = 1
             elseif policy[aspect] == "auto" then
                 aspects[aspect] = math.min(width / w, height / h)
+            elseif policy[aspect] == "cover" then
+                aspects[aspect] = math.max(width / w, height / h)
             end
         end
 
@@ -519,6 +521,7 @@ end
 -- @propertyvalue "auto" Honor the `resize` variable and preserve the aspect ratio.
 -- @propertyvalue "none" Do not resize at all.
 -- @propertyvalue "fit" Resize to the widget width.
+-- @propertyvalue "cover" Resize to fill widget and preserve the aspect ratio.
 -- @propemits true false
 -- @see vertical_fit_policy
 -- @see resize
@@ -534,6 +537,7 @@ end
 -- @propertyvalue "auto" Honor the `resize` variable and preserve the aspect ratio.
 -- @propertyvalue "none" Do not resize at all.
 -- @propertyvalue "fit" Resize to the widget height.
+-- @propertyvalue "cover" Resize to fill widget and preserve the aspect ratio.
 -- @propemits true false
 -- @see horizontal_fit_policy
 -- @see resize

--- a/tests/examples/wibox/widget/imagebox/horizontal_fit_policy.lua
+++ b/tests/examples/wibox/widget/imagebox/horizontal_fit_policy.lua
@@ -69,13 +69,15 @@ parent:add(l)
 l:add_widget_at(wibox.widget.textbox('horizontal_fit_policy = "auto"'), 1, 1)
 l:add_widget_at(wibox.widget.textbox('horizontal_fit_policy = "none"'), 2, 1)
 l:add_widget_at(wibox.widget.textbox('horizontal_fit_policy = "fit"'), 3, 1)
-l:add_widget_at(wibox.widget.textbox('imagebox size'), 4, 1)
+l:add_widget_at(wibox.widget.textbox('vertical_fit_policy = "cover"'), 4, 1)
+l:add_widget_at(wibox.widget.textbox('imagebox size'), 5, 1)
 
 for i,size in ipairs({16, 32, 64}) do
     l:add_widget_at(build_ib(size, "auto"), 1, i + 1)
     l:add_widget_at(build_ib(size, "none"), 2, i + 1)
     l:add_widget_at(build_ib(size, "fit" ), 3, i + 1)
-    l:add_widget_at(cell_centered_widget(wibox.widget.textbox(size..'x'..size)), 4, i + 1)
+    l:add_widget_at(build_ib(size, "cover"), 4, i + 1)
+    l:add_widget_at(cell_centered_widget(wibox.widget.textbox(size..'x'..size)), 5, i + 1)
 end
 
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/imagebox/vertical_fit_policy.lua
+++ b/tests/examples/wibox/widget/imagebox/vertical_fit_policy.lua
@@ -69,13 +69,15 @@ parent:add(l)
 l:add_widget_at(wibox.widget.textbox('vertical_fit_policy = "auto"'), 1, 1)
 l:add_widget_at(wibox.widget.textbox('versical_fit_policy = "none"'), 2, 1)
 l:add_widget_at(wibox.widget.textbox('vertical_fit_policy = "fit"'), 3, 1)
-l:add_widget_at(wibox.widget.textbox('imagebox size'), 4, 1)
+l:add_widget_at(wibox.widget.textbox('vertical_fit_policy = "cover"'), 4, 1)
+l:add_widget_at(wibox.widget.textbox('imagebox size'), 5, 1)
 
 for i,size in ipairs({16, 32, 64}) do
     l:add_widget_at(build_ib(size, "auto"), 1, i + 1)
     l:add_widget_at(build_ib(size, "none"), 2, i + 1)
     l:add_widget_at(build_ib(size, "fit" ), 3, i + 1)
-    l:add_widget_at(cell_centered_widget(wibox.widget.textbox(size..'x'..size)), 4, i + 1)
+    l:add_widget_at(build_ib(size, "cover"), 4, i + 1)
+    l:add_widget_at(cell_centered_widget(wibox.widget.textbox(size..'x'..size)), 5, i + 1)
 end
 
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This fit policy emulates the behaviour of CSS' `background-size: cover`

Signed-off-by: delta <darkussdelta@gmail.com>